### PR TITLE
deployment: update frontend and backend deployment to apps/v1

### DIFF
--- a/backend/chart/backend/templates/deployment.yaml
+++ b/backend/chart/backend/templates/deployment.yaml
@@ -1,10 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: backend-deployment
   labels:
     chart: backend
 spec:
+  selector:
+    matchLabels:
+      app: "backend-selector"
   template:
     metadata:
       labels:

--- a/frontend/chart/frontend/templates/deployment.yaml
+++ b/frontend/chart/frontend/templates/deployment.yaml
@@ -1,10 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend-deployment
   labels:
     chart: frontend
 spec:
+  selector:
+    matchLabels:
+      app: "frontend-selector"
   template:
     metadata:
       labels:


### PR DESCRIPTION
Update both deployments to use latest api `apps/v1` as `extensions/v1beta1` was deprecated in Kubernetes 1.16. Updating api required the selector filed to be added.